### PR TITLE
fix: add origCallId in Event interface

### DIFF
--- a/lib/webhook/models/webhook.model.ts
+++ b/lib/webhook/models/webhook.model.ts
@@ -18,6 +18,7 @@ enum HangUpCause {
 export interface Event {
 	event: EventType;
 	callId: string;
+	originalCallId: string;
 }
 
 export interface GenericCallEvent extends Event {
@@ -29,7 +30,6 @@ export interface GenericCallEvent extends Event {
 
 export interface NewCallEvent extends GenericCallEvent {
 	event: EventType.NEW_CALL;
-	originalCallId: string;
 	'user[]': string[];
 	'userId[]': string[];
 	'fullUserId[]': string[];


### PR DESCRIPTION
Co-Authored-By: Robert Deppe <deppe@sipgate.de>

## What is the purpose of the change

Not Only NewCallEvents have `origCallId`. Every event that has a `callId` also has `origCallid`. Therefore the field should be represented in the genereic `Event` interface.

## Brief change log

- 1 remove `origCallId` from interface `NewCallEvent`
- 2 introduce `origCallId` to interface `Event`
